### PR TITLE
Update appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,9 @@ environment:
   NOT_CRAN: "true"
   matrix:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-    R_URL: "https://cran.rstudio.com/bin/windows/base/R-3.4.4-win.exe"
-#  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
-#    R_URL: "https://cran.rstudio.com/bin/windows/base/R-devel-win.exe"
-#  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-#    R_URL: "https://cran.rstudio.com/bin/windows/base/R-devel-win.exe"
+    R_URL: "https://cran.rstudio.com/bin/windows/base/R-3.5.0-win.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+    R_URL: "https://cran.rstudio.com/bin/windows/base/R-devel-win.exe"
 
 notifications:
   - provider: Email
@@ -51,7 +49,7 @@ install:
   # Download and install Rtools
 
   - ps: (new-object net.webclient).DownloadFile(
-      "https://cran.rstudio.com/bin/windows/Rtools/Rtools34.exe",
+      "https://cran.rstudio.com/bin/windows/Rtools/Rtools35.exe",
       "C:\projects\rtools.exe")
   # - C:\projects\rtools.exe /S /D=C:\Rtools
   - C:\projects\rtools.exe /VERYSILENT /DIR=C:\Rtools


### PR DESCRIPTION
On appveyor, test on R 3.5.0 (the current release) and R-devel.
Use Rtools35 instead of Rtools34.

BTW, the travis build failure on macos seems also related to recent R update. The packages cached from previous version of R (3.4.4) may not work with R 3.5.0. Deleting cache on travis will solve the issue.