### PR TITLE
Documentation improvements: Fix typos, bugs, and inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ make sure that `julia` is found in the path. For more
 information see the `julia_setup()` function from
 [JuliaCall](https://github.com/JuliaInterop/JuliaCall).
 
-## Google Collab Notebooks
+## Google Colab Notebooks
 
 As a demonstration, check out the following notebooks:
 
@@ -162,7 +162,7 @@ Plotly is much prettier!
 
 If we want to have a more accurate solution, we can send `abstol` and `reltol`. Defaults are `1e-6` and `1e-3` respectively.
 Generally you can think of the digits of accuracy as related to 1 plus the exponent of the relative tolerance, so the default is
-two digits of accuracy. Absolute tolernace is the accuracy near 0.
+two digits of accuracy. Absolute tolerance is the accuracy near 0.
 
 In addition, we may want to choose to save at more time points. We do this by giving an array of values to save at as `saveat`.
 Together, this looks like:
@@ -458,7 +458,7 @@ tspan <- c(0.0, 100.0)
 constant_lags <- c(20.0)
 JuliaCall::julia_assign("u0", u0)
 JuliaCall::julia_assign("tspan", tspan)
-JuliaCall::julia_assign("constant_lags", tspan)
+JuliaCall::julia_assign("constant_lags", constant_lags)
 prob <- JuliaCall::julia_eval("DDEProblem(f, u0, h, tspan, constant_lags = constant_lags)")
 sol <- de$solve(prob,de$MethodOfSteps(de$Tsit5()))
 udf <- as.data.frame(t(sapply(sol$u,identity)))

--- a/vignettes/dae.Rmd
+++ b/vignettes/dae.Rmd
@@ -39,8 +39,8 @@ differential_vars <- c(TRUE,TRUE,FALSE)
 prob <- de$DAEProblem(f,du0,u0,tspan,differential_vars=differential_vars)
 sol <- de$solve(prob)
 udf <- as.data.frame(t(sapply(sol$u,identity)))
-plotly::plot_ly(udf, x = sol$t, y = ~V1, type = 'scatter', mode = 'lines') %>%
-  plotly::add_trace(y = ~V2) %>%
+plotly::plot_ly(udf, x = sol$t, y = ~V1, type = 'scatter', mode = 'lines') |>
+  plotly::add_trace(y = ~V2) |>
   plotly::add_trace(y = ~V3)
 ```
 

--- a/vignettes/dde.Rmd
+++ b/vignettes/dde.Rmd
@@ -39,11 +39,11 @@ tspan <- c(0.0, 100.0)
 constant_lags <- c(20.0)
 JuliaCall::julia_assign("u0", u0)
 JuliaCall::julia_assign("tspan", tspan)
-JuliaCall::julia_assign("constant_lags", tspan)
+JuliaCall::julia_assign("constant_lags", constant_lags)
 prob <- JuliaCall::julia_eval("DDEProblem(f, u0, h, tspan, constant_lags = constant_lags)")
 sol <- de$solve(prob,de$MethodOfSteps(de$Tsit5()))
 udf <- as.data.frame(t(sapply(sol$u,identity)))
-plotly::plot_ly(udf, x = sol$t, y = ~V1, type = 'scatter', mode = 'lines') %>% plotly::add_trace(y = ~V2)
+plotly::plot_ly(udf, x = sol$t, y = ~V1, type = 'scatter', mode = 'lines') |> plotly::add_trace(y = ~V2)
 ```
 
 ![delay](https://user-images.githubusercontent.com/1814174/39023532-10bdd750-43f0-11e8-837d-156d33ea2f99.png)

--- a/vignettes/ode.Rmd
+++ b/vignettes/ode.Rmd
@@ -50,6 +50,10 @@ This gives back a solution object for which `sol$t` are the time points
 and `sol$u` are the values. We can treat the solution as a continuous object
 in time via
 
+```R
+sol$.(0.2)
+```
+
 and a high order interpolation will compute the value at `t=0.2`. We can check
 the solution by plotting it:
 
@@ -77,7 +81,7 @@ Here we utilized the parameter array `p`. Thus we use `diffeqr::ode.solve` like 
 
 ```R
 u0 <- c(1.0,0.0,0.0)
-tspan <- list(0.0,100.0)
+tspan <- c(0.0,100.0)
 p <- c(10.0,28.0,8/3)
 prob <- de$ODEProblem(f, u0, tspan, p)
 sol <- de$solve(prob)

--- a/vignettes/sde.Rmd
+++ b/vignettes/sde.Rmd
@@ -30,7 +30,7 @@ g <- function(u,p,t) {
   return(0.87*u)
 }
 u0 <- 1/2
-tspan <- list(0.0,1.0)
+tspan <- c(0.0,1.0)
 prob <- de$SDEProblem(f,g,u0,tspan)
 sol <- de$solve(prob)
 udf <- as.data.frame(t(sapply(sol$u,identity)))


### PR DESCRIPTION
## Summary

This PR fixes several documentation issues to improve accuracy and consistency:

- **Fixed typo**: "Google Collab" → "Google Colab" 
- **Fixed typo**: "tolernace" → "tolerance"
- **Fixed critical bug**: DDE example had `constant_lags` incorrectly assigned `tspan` value instead of `constant_lags` variable (affected both README.md and vignettes/dde.Rmd)
- **Fixed inconsistencies**: Changed `list()` to `c()` for `tspan` in vignettes (ode.Rmd, sde.Rmd) to match README and proper R vector syntax
- **Standardized pipe operators**: Updated `%>%` to `|>` (native R 4.1+ pipe) in dae.Rmd and dde.Rmd for consistency with README
- **Added missing code**: Included the interpolation example `sol$.(0.2)` in ode.Rmd that was referenced but not shown

## Test plan

- [x] Reviewed all changes for accuracy
- [x] Verified syntax corrections match R best practices
- [x] Confirmed consistency between README and vignettes
- [x] Validated that the DDE bug fix uses correct variable assignment

## Files changed

- README.md: Fixed typos and DDE bug
- vignettes/ode.Rmd: Added missing code example, fixed tspan syntax
- vignettes/sde.Rmd: Fixed tspan syntax
- vignettes/dde.Rmd: Fixed critical bug and pipe operator
- vignettes/dae.Rmd: Standardized pipe operator

@ChrisRackauckas - These are practical documentation improvements that fix bugs and inconsistencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)